### PR TITLE
fix example code in 2019-01-30-plugins.md

### DIFF
--- a/_posts/2019-01-30-plugins.md
+++ b/_posts/2019-01-30-plugins.md
@@ -18,6 +18,7 @@ Each plugin should provide a class, that is derived from the `org.pf4j.Plugin` c
 
 ```java
 import org.pf4j.Plugin;
+import org.pf4j.PluginException;
 import org.pf4j.PluginWrapper;
 
 public class MyPlugin extends Plugin {


### PR DESCRIPTION
I've fixed a little problem. The example code in `2019-01-30-plugins.md` misses an `import` statement.